### PR TITLE
Add method to retrieve album by upc

### DIFF
--- a/src/models/album.rs
+++ b/src/models/album.rs
@@ -1,8 +1,9 @@
 //! [Album API](https://developers.deezer.com/api/album)
 #![warn(missing_docs)]
+
 use serde::{Deserialize, Serialize};
 
-use crate::models::{Artist, ContributorArtist, DeezerArray, DeezerObject, Genre, Track};
+use crate::models::{Artist, ContributorArtist, DeezerArray, DeezerObject, DeezerUpcObject, Genre, Track, Upc};
 use crate::Result;
 
 /// Contains all the information provided for an Album.
@@ -130,6 +131,12 @@ pub struct Album {
 impl DeezerObject for Album {
     fn get_api_url(id: u64) -> String {
         format!("album/{}", id)
+    }
+}
+
+impl DeezerUpcObject for Album {
+    fn get_api_url(upc: Upc) -> String {
+        format!("album/upc:{}", upc)
     }
 }
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -96,6 +96,20 @@ pub trait DeezerObject: serde::de::DeserializeOwned {
     }
 }
 
+/// A by upc queryable api object of the deezer api
+#[async_trait]
+pub trait DeezerUpcObject: serde::de::DeserializeOwned {
+    /// Get a relative api url for the given `upc`
+    fn get_api_url(upc: Upc) -> String;
+
+    /// Fetch an api object with the given `upc`
+    async fn get_by_upc(upc: Upc) -> Result<Option<Self>> {
+        let client = DeezerClient::new();
+
+        client.get_entity_by_upc(upc).await
+    }
+}
+
 // Represents an api object which has a list method
 #[async_trait]
 pub trait DeezerEnumerable: DeezerObject {
@@ -107,3 +121,5 @@ pub trait DeezerEnumerable: DeezerObject {
         client.get_all().await
     }
 }
+
+pub type Upc = String;


### PR DESCRIPTION
I've tried hard to create general purpose identifier enum (u64/isrc/upc) but since you cannot limit method parameter to enum variant (maybe we would be if const generics get stabilized?) there's no way to check if correct identifier is passed to a method at compile time. That would require additional error handling and be error prone (eg someone by accident passes isrc to get_album_by_code). Therefore... this is current approach. Once we get over this, I will continue with Track/Isrc.